### PR TITLE
fix: use forLanguageTag to create new Locale

### DIFF
--- a/android/src/main/java/com/localizationsettings/LocalizationSettingsModule.kt
+++ b/android/src/main/java/com/localizationsettings/LocalizationSettingsModule.kt
@@ -23,10 +23,12 @@ class LocalizationSettingsModule internal constructor(context: ReactApplicationC
    * if country is not available in locale, then use system defaults (even if it's not 100% correct, like "pl-US")
    **/
   private fun getLanguageTag(language: String): String {
-    // if language have format language_COUNTRY, then return it
-    if (Locale(language).country != "") return Locale(language).toLanguageTag()
+    val locale = Locale.forLanguageTag(language);
+
+    // if language has format language-COUNTRY, then return it
+    if (locale.country != "") return locale.toLanguageTag()
     // fallback for system country
-    return "$language-${Locale.getDefault().country}"
+    return Locale(locale.language, Locale.getDefault().country).toLanguageTag()
   }
 
 


### PR DESCRIPTION
as the [public constructor](https://developer.android.com/reference/java/util/Locale#public-constructors) accepts a language ("pl”), not a language tag (“pl-PL”). This fixes an issue where the country is added on every save (”pl-PL-PL-PL”). See factory method [forLanguageTag](https://developer.android.com/reference/java/util/Locale#forLanguageTag(java.lang.String))