### PR TITLE
[iOS] Fix cannot detect language script and variant + use regionCode

### DIFF
--- a/ios/LocalizationSettings.mm
+++ b/ios/LocalizationSettings.mm
@@ -10,11 +10,11 @@ RCT_EXPORT_MODULE()
  **/
 -(NSString*) getLanguageTag:(NSString *)language {
     NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:language];
-    if ([locale countryCode]) {
+    if ([locale regionCode]) {
         return [locale localeIdentifier];
     }
     NSLocale *currentLocale = [NSLocale currentLocale];
-    return [[locale languageCode] stringByAppendingFormat:@"-%@", [currentLocale countryCode]];
+    return [[locale languageIdentifier] stringByAppendingFormat:@"-%@", [currentLocale regionCode]];
 }
 
 -(NSString*) getUserLocale {

--- a/ios/LocalizationSettings.mm
+++ b/ios/LocalizationSettings.mm
@@ -10,11 +10,23 @@ RCT_EXPORT_MODULE()
  **/
 -(NSString*) getLanguageTag:(NSString *)language {
     NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:language];
-    if ([locale regionCode]) {
+    NSString *countryCode;
+
+    if (@available(iOS 17.0, *)) {
+        countryCode = [locale regionCode];
+    } else {
+        countryCode = [locale countryCode];
+    }
+
+    if (countryCode) {
         return [locale localeIdentifier];
     }
-    NSLocale *currentLocale = [NSLocale currentLocale];
-    return [[locale languageIdentifier] stringByAppendingFormat:@"-%@", [currentLocale regionCode]];
+
+    if (@available(iOS 17.0, *)) {
+        return [[locale languageIdentifier] stringByAppendingFormat:@"-%@", countryCode];
+    }
+
+    return [[[locale languageCode] stringByAppendingFormat:@"-%@", [locale scriptCode]] stringByAppendingFormat:@"-%@", countryCode];
 }
 
 -(NSString*) getUserLocale {


### PR DESCRIPTION
- Fixed an issue causing language script and variant is ignored if not using `regionCode` (`countryCode`) when setting language. For example: `zh-Hans` became `zh-US` instead of `zh-Hans-US`.
- NSLocale `countryCode` is deprecated so I migrate using NSLocale `regionCode` instead