### PR TITLE
feat: support react-native 0.74 (newArch) on Android

### DIFF
--- a/android/src/main/java/com/localizationsettings/LocalizationSettingsModule.kt
+++ b/android/src/main/java/com/localizationsettings/LocalizationSettingsModule.kt
@@ -96,7 +96,7 @@ class LocalizationSettingsModule internal constructor(context: ReactApplicationC
   /**
    * Expose constants to react-native
    **/
-  override fun getConstants(): MutableMap<String, String?>? {
+  override fun getTypedExportedConstants(): MutableMap<String, String?>? {
     val constants: MutableMap<String, String?> = HashMap()
     constants["language"] = getCurrentLanguage()
     return constants

--- a/android/src/oldarch/LocalizationSettingsSpec.kt
+++ b/android/src/oldarch/LocalizationSettingsSpec.kt
@@ -9,4 +9,9 @@ abstract class LocalizationSettingsSpec internal constructor(context: ReactAppli
 
   abstract fun getLanguage(promise: Promise)
   abstract fun setLanguage(language: String)
+  abstract fun getTypedExportedConstants(): Map<String, String?>?
+
+  override fun getConstants(): Map<String, String?>? {
+    return getTypedExportedConstants()
+  }
 }


### PR DESCRIPTION
Fix issue #15

There was a change in react-native 0.74 for the new architecture.
This will break the newArch for an older version.
