### PR TITLE
feat: add getLanguageAsync

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,9 +1,12 @@
-import * as React from 'react';
-
+import React from 'react';
 import { StyleSheet, View, Text, Button } from 'react-native';
-import { ReactNativeLanguageDetector } from 'react-native-localization-settings';
 import i18next from 'i18next';
 import { initReactI18next, useTranslation } from 'react-i18next';
+import {
+  getLanguage,
+  getLanguageAsync,
+  ReactNativeLanguageDetector,
+} from 'react-native-localization-settings';
 
 i18next
   .use(ReactNativeLanguageDetector)
@@ -35,21 +38,26 @@ i18next
 
 export default function App() {
   const { t } = useTranslation();
+  const [lang, setLang] = React.useState(getLanguage());
 
+  const changeLanguage = (language: string) => () => {
+    i18next.changeLanguage(language);
+    setLang(getLanguage());
+  };
   return (
     <View style={styles.container}>
       <Text>{t('key')}</Text>
+      <Text>{lang}</Text>
+      <Button title={'change to pl'} onPress={changeLanguage('pl-PL')} />
+      <Button title={'change to en'} onPress={changeLanguage('en-US')} />
+      <Button title={'change to fr'} onPress={changeLanguage('fr-FR')} />
       <Button
-        title={'change to pl'}
-        onPress={() => i18next.changeLanguage('pl-PL')}
+        title={'get language sync'}
+        onPress={() => console.log(getLanguage())}
       />
       <Button
-        title={'change to en'}
-        onPress={() => i18next.changeLanguage('en-US')}
-      />
-      <Button
-        title={'change to fr'}
-        onPress={() => i18next.changeLanguage('fr-FR')}
+        title={'get language async'}
+        onPress={() => getLanguageAsync().then(console.log)}
       />
     </View>
   );

--- a/example/ios/Localizable.xcstrings
+++ b/example/ios/Localizable.xcstrings
@@ -1,5 +1,9 @@
 {
   "sourceLanguage" : "en",
-  "strings" : {},
+  "strings" : {
+    "Key" : {
+      "extractionState" : "manual"
+    }
+  },
   "version" : "1.0"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,14 +25,34 @@ const LocalizationSettings = LocalizationSettingsModule
     );
 
 /**
- * Get language
+ * Get language (sync)
  * @returns Language in IETF BCP 47 format (like 'en-US')
  * @example
  * console.log(getLanguage())
  */
 export function getLanguage(): string {
-  LocalizationSettings.getLanguage();
   return LocalizationSettings.getConstants().language.split('_')[0];
+}
+
+/**
+ * Get language (async)
+ * @param fallback - fallback language
+ * @returns Promise with Language in IETF BCP 47 format (like 'en-US')
+ * @example
+ * getLanguageAsync().then(console.log)
+ */
+export function getLanguageAsync(fallback?: string): Promise<string> {
+  return LocalizationSettings.getLanguage()
+    .then((res: string) => res.split('_'))
+    .then((res: string[]) => {
+      if (res[0]) {
+        return res[0];
+      }
+      if (fallback) {
+        return fallback;
+      }
+      throw new Error('Invalid language format');
+    });
 }
 
 /**


### PR DESCRIPTION
I've discovered that constants on the old architecture are only called once when the module is loaded, so it's safer to call `getLanguageAsync` asynchronously on the old arch.